### PR TITLE
refactor error messages & remove logging

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,2 +1,10 @@
 general:
   build_dir: consumer
+dependencies:
+  pre:
+    - sudo rm -rf /usr/local/go; wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz; sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz; export GOROOT=/usr/local/go; export PATH=$GOROOT/bin:$PATH; go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html;
+test:
+  override:
+    - gocov test > coverage.json
+  post:
+    - gocov-html coverage.json > $CIRCLE_ARTIFACTS/coverage.html

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ dependencies:
     - "sudo rm -rf /usr/local/go; wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz; sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz; export GOROOT=/usr/local/go; export PATH=$GOROOT/bin:$PATH; go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html;"
 general: 
   build_dir: consumer
+  test_dir: consumer
 test: 
   override: 
     - "gocov test > coverage.json"

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,12 @@
-general:
+--- 
+dependencies: 
+  pre: 
+    - "sudo rm -rf /usr/local/go; wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz; sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz; export GOROOT=/usr/local/go; export PATH=$GOROOT/bin:$PATH; go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html;"
+general: 
   build_dir: consumer
-dependencies:
-  pre:
-    - sudo rm -rf /usr/local/go; wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz; sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz; export GOROOT=/usr/local/go; export PATH=$GOROOT/bin:$PATH; go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html;
-test:
-  override:
-    - gocov test > coverage.json
-  post:
-    - gocov-html coverage.json > $CIRCLE_ARTIFACTS/coverage.html
+test: 
+  override: 
+    - "gocov test > coverage.json"
+  post: 
+    - "gocov-html coverage.json > $CIRCLE_ARTIFACTS/coverage.html"
+

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -28,14 +29,16 @@ func TestConsume(t *testing.T) {
 		{
 			&DefaultIterator{queue: consumeMsgErrorQueueCaller{}, consumer: consInstTest},
 			nil,
-			errors.New("Error while consuming"),
+			errors.New("Error consuming messages"),
 			nil,
 		},
 	}
 
 	for _, test := range tests {
 		actMsgs, actErr := test.iterator.consume()
-		if !reflect.DeepEqual(actMsgs, test.expMsgs) || !reflect.DeepEqual(test.iterator.consumer, test.expCons) || !reflect.DeepEqual(test.expErr, actErr) {
+		if !reflect.DeepEqual(actMsgs, test.expMsgs) ||
+			!reflect.DeepEqual(test.iterator.consumer, test.expCons) ||
+			(test.expErr != nil && !strings.Contains(actErr.Error(), test.expErr.Error())) {
 			t.Errorf("Expected: msgs: %v, error: %v, consumer: %v\nActual: msgs: %v, error: %v consumer: %v.",
 				test.expMsgs, test.expErr, test.expCons, actMsgs, actErr, test.iterator.consumer)
 		}


### PR DESCRIPTION
1. Logging to the default log.Logger is not cool, as clients may override the flags and patterns.
2. Error logs should not be spread across different log messages. 
3. The client should be responsible for logging the returned error messages. 

Adding support for logging file/method/line number could follow, this way we could even have stacktrace-like error logging.

Thoughts? 