### PR TITLE
Close idle connections on server error

### DIFF
--- a/consumer/queue-caller.go
+++ b/consumer/queue-caller.go
@@ -127,7 +127,7 @@ func (caller defaultHTTPCaller) DoReq(method, url string, body io.Reader, header
 		resp.Body.Close()
 		if resp.StatusCode >= 500 {
 			// This might be a problem with the server instance, which may have been taken out
-			// of the DNS pool, but becuase we might still have a tcp connection open, we'll
+			// of the DNS pool, but because we might still have a tcp connection open, we'll
 			// never re-do the DNS lookup and get a connection to a working server.  So when we
 			// get 5xx, close idle connections to force the next requests to re-connect.
 			if t, ok := caller.client.Transport.(*http.Transport); ok {


### PR DESCRIPTION
In order to ensure we do a new DNS lookup when calls to the server are
failing, close idle connections in this case.  This ensures we don't end
up making requests to a broken server that's been taken out of the DNS
pool because it's unhealthy.

Also, discard unused Body to ensure re-use in the typical case where we
don't want to close the connection.

(UNTESTED)