### PR TITLE
Add an ageing http client

### DIFF
--- a/consumer/ageing_client.go
+++ b/consumer/ageing_client.go
@@ -1,0 +1,31 @@
+package consumer
+
+import (
+	"net/http"
+	"time"
+	"github.com/golang/go/src/pkg/log"
+)
+
+type AgeingClient struct {
+	Client http.Client
+
+	MaxAge time.Duration
+}
+
+func (client AgeingClient) StartAgeingProcess() {
+	log.Printf("INFO: Starting aging [%d]", client.MaxAge)
+	ticker := time.NewTicker(client.MaxAge)
+	quit := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				log.Print("INFO: Closing idle connections")
+				client.Client.Transport.(*http.Transport).CloseIdleConnections()
+			case <-quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}

--- a/consumer/ageing_client.go
+++ b/consumer/ageing_client.go
@@ -3,28 +3,23 @@ package consumer
 import (
 	"net/http"
 	"time"
-	"github.com/golang/go/src/pkg/log"
+	"log"
 )
 
 type AgeingClient struct {
 	Client http.Client
-
 	MaxAge time.Duration
 }
 
 func (client AgeingClient) StartAgeingProcess() {
 	log.Printf("INFO: Starting aging [%d]", client.MaxAge)
 	ticker := time.NewTicker(client.MaxAge)
-	quit := make(chan struct{})
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
 				log.Print("INFO: Closing idle connections")
 				client.Client.Transport.(*http.Transport).CloseIdleConnections()
-			case <-quit:
-				ticker.Stop()
-				return
 			}
 		}
 	}()

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -12,15 +12,16 @@ type Consumer struct {
 	consumers   []QueueConsumer
 }
 
-func NewConsumer(config QueueConfig, handler func(m Message), client http.Client) Consumer {
+func NewConsumer(config QueueConfig, handler func(m Message), agingClient AgeingClient) Consumer {
 	streamCount := 1
 	if config.StreamCount > 0 {
 		streamCount = config.StreamCount
 	}
 	consumers := make([]QueueConsumer, streamCount)
 	for i := 0; i < streamCount; i++ {
-		consumers[i] = NewQueueConsumer(config, handler, client)
+		consumers[i] = NewQueueConsumer(config, handler, agingClient.Client)
 	}
+	agingClient.StartAgeingProcess()
 
 	return Consumer{streamCount, consumers}
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -12,7 +12,20 @@ type Consumer struct {
 	consumers   []QueueConsumer
 }
 
-func NewConsumer(config QueueConfig, handler func(m Message), agingClient AgeingClient) Consumer {
+func NewConsumer(config QueueConfig, handler func(m Message), client http.Client) Consumer {
+	streamCount := 1
+	if config.StreamCount > 0 {
+		streamCount = config.StreamCount
+	}
+	consumers := make([]QueueConsumer, streamCount)
+	for i := 0; i < streamCount; i++ {
+		consumers[i] = NewQueueConsumer(config, handler, client)
+	}
+
+	return Consumer{streamCount, consumers}
+}
+
+func NewAgeingConsumer(config QueueConfig, handler func(m Message), agingClient AgeingClient) Consumer {
 	streamCount := 1
 	if config.StreamCount > 0 {
 		streamCount = config.StreamCount


### PR DESCRIPTION
The client has a max age for a tcp connection, after which it closes
all idle connections.  There is a chance that the connection may
persist after a single close, but since the connection is idle most of
the time it will clean it up eventually.