### PR TITLE
Add Batching

### DIFF
--- a/consumer/batch_consumer.go
+++ b/consumer/batch_consumer.go
@@ -1,0 +1,73 @@
+package consumer
+
+import (
+	"errors"
+	"log"
+	"net/http"
+)
+
+type DefaultBatchedQueueConsumer struct {
+	baseQueueConsumer
+	handler func(m []Message)
+}
+
+func NewBatchedQueueConsumer(config QueueConfig, handler func(m []Message), client http.Client) QueueConsumer {
+	offset := "largest"
+	if len(config.Offset) > 0 {
+		offset = config.Offset
+	}
+
+	queue := &defaultQueueCaller{
+		addrs:            config.Addrs,
+		group:            config.Group,
+		topic:            config.Topic,
+		offset:           offset,
+		autoCommitEnable: config.AutoCommitEnable,
+		caller:           defaultHTTPCaller{config.Queue, config.AuthorizationKey, client},
+	}
+	return &DefaultBatchedQueueConsumer{baseQueueConsumer{config, queue, nil, make(chan bool, 1)}, handler}
+}
+
+func (c *DefaultBatchedQueueConsumer) consume() ([]Message, error) {
+	q := c.queue
+	if c.consumer == nil {
+		cInst, err := q.createConsumerInstance()
+		if err != nil {
+			log.Printf("ERROR - creating consumer instance: %s", err.Error())
+			return nil, err
+		}
+		c.consumer = &cInst
+	}
+
+	msgs, err := q.consumeMessages(*c.consumer)
+	if err != nil {
+		log.Printf("ERROR - consuming messages: %s", err.Error())
+		errD := q.destroyConsumerInstance(*c.consumer)
+		if errD != nil {
+			log.Printf("ERROR - deleting consumer instance: %s", errD.Error())
+		}
+		c.consumer = nil
+		return nil, err
+	}
+
+	if c.config.ConcurrentProcessing {
+		return nil, errors.New("This batched queue consumer does not support concurrent processing! Please set ConcurrentProcessing to false.")
+	}
+
+	c.handler(msgs)
+
+	if c.config.AutoCommitEnable == false {
+		err = q.commitOffsets(*c.consumer)
+		if err != nil {
+			log.Printf("ERROR -  commiting offsets: %s", err.Error())
+			errD := q.destroyConsumerInstance(*c.consumer)
+			if errD != nil {
+				log.Printf("ERROR - deleting consumer instance: %s", errD.Error())
+			}
+			c.consumer = nil
+			return nil, err
+		}
+	}
+
+	return msgs, nil
+}

--- a/consumer/batch_consumer_test.go
+++ b/consumer/batch_consumer_test.go
@@ -1,0 +1,17 @@
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchConsumer(t *testing.T) {
+	consumer := &DefaultBatchedQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, consumer: consInstTest}, func(m []Message) {
+		assert.Equal(t, msgsTest, m)
+	}}
+
+	msgs, err := consumer.consume()
+	assert.Nil(t, err)
+	assert.Equal(t, msgsTest, msgs)
+}

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -26,6 +26,20 @@ func NewConsumer(config QueueConfig, handler func(m Message), client http.Client
 	return Consumer{streamCount, consumers}
 }
 
+func NewBatchedConsumer(config QueueConfig, handler func(m []Message), client http.Client) Consumer {
+	streamCount := 1
+	if config.StreamCount > 0 {
+		streamCount = config.StreamCount
+	}
+
+	consumers := make([]QueueConsumer, streamCount)
+	for i := 0; i < streamCount; i++ {
+		consumers[i] = NewBatchedQueueConsumer(config, handler, client)
+	}
+
+	return Consumer{streamCount, consumers}
+}
+
 func NewAgeingConsumer(config QueueConfig, handler func(m Message), agingClient AgeingClient) Consumer {
 	streamCount := 1
 	if config.StreamCount > 0 {

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -16,19 +16,19 @@ func TestConsume(t *testing.T) {
 		expCons  *consumer //DefaultIterator's consumerInstance
 	}{
 		{
-			&DefaultQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, handler: func(m Message) {}, consumer: consInstTest},
+			&DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, consumer: consInstTest}, func(m Message) {}},
 			msgsTest,
 			nil,
 			consInstTest,
 		},
 		{
-			&DefaultQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, handler: func(m Message) {}},
+			&DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}}, func(m Message) {}},
 			msgsTest,
 			nil,
 			consInstTest,
 		},
 		{
-			&DefaultQueueConsumer{config: QueueConfig{}, queue: consumeMsgErrorQueueCaller{}, handler: func(m Message) {}, consumer: consInstTest},
+			&DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: consumeMsgErrorQueueCaller{}, consumer: consInstTest}, func(m Message) {}},
 			nil,
 			errors.New("Error while consuming"),
 			nil,
@@ -45,13 +45,13 @@ func TestConsume(t *testing.T) {
 }
 
 func TestConsumeAndHandleMessagesRecoversFromPanic(t *testing.T) {
-	c := DefaultQueueConsumer{config: QueueConfig{BackoffPeriod: 1}, queue: consumeMsgPanicQueueCaller{}, handler: func(m Message) {}}
+	c := DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{BackoffPeriod: 1}, queue: consumeMsgPanicQueueCaller{}}, func(m Message) {}}
 	c.consumeAndHandleMessages()
 }
 
 func TestConsumeWhileActiveTerminates(t *testing.T) {
 	sdChan := make(chan bool)
-	c := DefaultQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, handler: func(m Message) {}, shutdownChan: sdChan}
+	c := DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, shutdownChan: sdChan}, func(m Message) {}}
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -65,7 +65,7 @@ func TestConsumeWhileActiveTerminates(t *testing.T) {
 func TestStartStop(t *testing.T) {
 	consumers := make([]QueueConsumer, 2)
 	for i := 0; i < 2; i++ {
-		consumers[i] = &DefaultQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, handler: func(m Message) {}, shutdownChan: make(chan bool)}
+		consumers[i] = &DefaultQueueConsumer{baseQueueConsumer{config: QueueConfig{}, queue: defaultTestQueueCaller{}, shutdownChan: make(chan bool)}, func(m Message) {}}
 	}
 	c := Consumer{2, consumers}
 


### PR DESCRIPTION
Add a new queue consumer type which supports forwarding the entire batch of Kafka messages as an array, rather than iterating over the array and forwarding each message individually.

This is to solve race/ordering conditions in notifications-push.